### PR TITLE
potential-jitter-fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ volatile unsigned char 	ADC_POT_sel_cnt = 0;
 #define MANUAL_ADDR_WIDE			(MANUAL_ADDR_MAX_VAL/MANUAL_ADDR_STEPS)
 
 #define KEY_MIDDLE_SECTION_MASK					0x7F0000F003FFFEFC
-#define KEY_MIDDLE_SECTION_ALL_OFF_MASK 		0x070000F003FE0EFC			
+#define KEY_MIDDLE_SECTION_ALL_OFF_MASK 		0x070000F003FE0EFC
 
 #define EXT_DAC_CH_0	0x00
 #define EXT_DAC_CH_1	0x01
@@ -44,19 +44,19 @@ volatile unsigned char 	ADC_POT_sel_cnt = 0;
 #define ADC_TIMEMULTIPLY_Ch_2	0x05
 #define ADC_STAGEADDRESS_Ch_1	0x06
 #define ADC_STAGEADDRESS_Ch_2	0x07
-	
+
 //Union with flags which allows to update different parts of panel
 typedef union
 {
 	struct {
-		unsigned char MainDisplay:1;	
+		unsigned char MainDisplay:1;
 		unsigned char StepsDisplay:1;
 		unsigned char OT1:1;
 		unsigned char OT2:1;
 		unsigned char OT3:1;
 		unsigned char OT4:1;
 		unsigned char OT5:1;
-		unsigned char OT6:1;		
+		unsigned char OT6:1;
 	} b;
 	unsigned char value;
 } uDisplayUpdateFlag;
@@ -119,7 +119,7 @@ volatile unsigned char gSequencer2_AdvanceStep = 0;
 volatile unsigned char gStrobeKey = 0;
 
 //Variable used for key lock during the VIEW_MODE key changes steps options
-volatile unsigned char key_locked = 0;	
+volatile unsigned char key_locked = 0;
 volatile unsigned char gKeysNotValid = 0;
 
 #define STEP_TIMER_FREQ_OUT		8000			//250uSec per timer period
@@ -161,21 +161,21 @@ volatile uint16_t average_index[2][32];
 volatile long long acc;
 
 unsigned char GetNextStep(unsigned char _Section, unsigned char _StepNum);
-	
+
 //Current patches bank
 volatile unsigned char bank = 1;
 volatile unsigned char strobe_banana_flag1 = 0, strobe_banana_flag2 = 0;
 volatile unsigned int save_counter = 0, load_counter = 0;
 volatile unsigned char advanced_counter_1 = 0, advanced_counter_2 = 0;
 
-uint16_t counterL = 0; 
+uint16_t counterL = 0;
 uint16_t counterR = 0;
 
 //ADC interrupt handler
 void ADC_IRQHandler()
 {
 	unsigned char NeedInc = 0, i;
-	
+
 	//If expander is connected we should scan its sliders
 	if(Is_Expander_Present())
 	{
@@ -193,10 +193,10 @@ void ADC_IRQHandler()
 			ADC_POTS_selector_Ch(ADC_POT_sel_cnt+1);
 		};
 	}
-		
+
 	//ADC1 conversation complete
-	if ( ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC) == SET) {				
-		
+	if ( ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC) == SET) {
+
 		//Calculate average of 10 measurements for voltage sliders
 		if (  (ADC_POT_sel_cnt<=15)) {
 			if ( (Steps[1][ADC_POT_sel_cnt].b.WaitVoltageSlider == 1) ) {
@@ -205,17 +205,17 @@ void ADC_IRQHandler()
 					};
 			} else {
 				average_array[1][ADC_POT_sel_cnt][average_index[1][ADC_POT_sel_cnt]] = (uint16_t) (ADC1->DR);
-				
+
 				average_index[1][ADC_POT_sel_cnt]++;
 				if(average_index[1][ADC_POT_sel_cnt] == NUMS) average_index[1][ADC_POT_sel_cnt] = 0;
-				
+
 				acc = 0;
 				for(i = 0; i < NUMS; i++)
 				{
 					acc += average_array[1][ADC_POT_sel_cnt][i];
 				}
 				Steps[1][ADC_POT_sel_cnt].b.VLevel = acc/NUMS;
-				
+
 				//Steps[1][ADC_POT_sel_cnt].b.VLevel = ((unsigned int) (ADC1->DR)+(unsigned int) Steps[1][ADC_POT_sel_cnt].b.VLevel)/2;
 			};
 			if ( (Steps[0][ADC_POT_sel_cnt].b.WaitVoltageSlider == 1) ) {
@@ -224,10 +224,10 @@ void ADC_IRQHandler()
 			};
 			} else {
 								average_array[0][ADC_POT_sel_cnt][average_index[0][ADC_POT_sel_cnt]] = (uint16_t) (ADC1->DR);
-				
+
 				average_index[0][ADC_POT_sel_cnt]++;
 				if(average_index[0][ADC_POT_sel_cnt] == NUMS) average_index[0][ADC_POT_sel_cnt] = 0;
-				
+
 				acc = 0;
 				for(i = 0; i < NUMS; i++)
 				{
@@ -237,9 +237,10 @@ void ADC_IRQHandler()
 				//Steps[0][ADC_POT_sel_cnt].b.VLevel = ((unsigned int) (ADC1->DR)+(unsigned int) Steps[0][ADC_POT_sel_cnt].b.VLevel)/2;
 			};
 			NeedInc = 1;
-		};	
+		};
 
-		//If expander is connected calculate additional voltagesH
+		//If expander is connected calculate additional voltages
+		if(Is_Expander_Present())
 		{
 			if (  (ADC_POT_sel_cnt>=40 && (ADC_POT_sel_cnt<=55))) {
 				if ( (Steps[1][ADC_POT_sel_cnt-24].b.WaitVoltageSlider == 1) ) {
@@ -258,36 +259,36 @@ void ADC_IRQHandler()
 				};
 				NeedInc = 1;
 			}
-			
+
 			//Calculate average of 2 measurements for time sliders
 				if ((ADC_POT_sel_cnt>=56) && (ADC_POT_sel_cnt<=71)) {
 				Steps[0][ADC_POT_sel_cnt-40].b.TLevel = (Steps[0][ADC_POT_sel_cnt-40].b.TLevel+(unsigned int)(ADC1->DR))/2;
-				Steps[1][ADC_POT_sel_cnt-40].b.TLevel = (Steps[1][ADC_POT_sel_cnt-40].b.TLevel+(unsigned int)(ADC1->DR))/2;			
+				Steps[1][ADC_POT_sel_cnt-40].b.TLevel = (Steps[1][ADC_POT_sel_cnt-40].b.TLevel+(unsigned int)(ADC1->DR))/2;
 				NeedInc = 1;
 			};
 		}
 		if ((ADC_POT_sel_cnt>=24) && (ADC_POT_sel_cnt<=39)) {
 			Steps[0][ADC_POT_sel_cnt-24].b.TLevel = (Steps[0][ADC_POT_sel_cnt-24].b.TLevel+(unsigned int)(ADC1->DR))/2;
-			Steps[1][ADC_POT_sel_cnt-24].b.TLevel = (Steps[1][ADC_POT_sel_cnt-24].b.TLevel+(unsigned int)(ADC1->DR))/2;			
+			Steps[1][ADC_POT_sel_cnt-24].b.TLevel = (Steps[1][ADC_POT_sel_cnt-24].b.TLevel+(unsigned int)(ADC1->DR))/2;
 			NeedInc = 1;
 		};
-		
+
 
 		//Clear end of conversion flag
 		ADC_ClearFlag(ADC1, ADC_FLAG_EOC);
-		
+
 	}
-	
+
 	//ADC2 used for external inputs conversion
 		if ( ADC_GetFlagStatus(ADC2, ADC_FLAG_EOC) == SET ) {
 		if ((ADC_POT_sel_cnt>=16) && (ADC_POT_sel_cnt<=23)) {
  			AddData[ADC_POT_sel_cnt-16] = (unsigned int)(ADC2->DR);
-			NeedInc = 1;			
+			NeedInc = 1;
 		};
 		ADC_ClearFlag(ADC2, ADC_FLAG_EOC);
-	
+
 	};
-	
+
 	//Calculate next channel to measure
 	if(Is_Expander_Present())
 	{
@@ -320,36 +321,36 @@ void mADC_init(void)
 	ADC_InitTypeDef ADC_InitType;
 	TIM_TimeBaseInitTypeDef TimeBaseInit;
 	NVIC_InitTypeDef nvicStructure;
-	
+
 	//Timer init
-	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM2, ENABLE); 
-		
+	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM2, ENABLE);
+
 	TIM_TimeBaseStructInit(&TimeBaseInit);
   TimeBaseInit.TIM_Prescaler 			= 0;
 	TimeBaseInit.TIM_CounterMode 		= TIM_CounterMode_Up;
   TimeBaseInit.TIM_Period 				= 4200-1;// for 40kHz
-	TimeBaseInit.TIM_ClockDivision 	= TIM_CKD_DIV1;	
-  TIM_TimeBaseInit(TIM2, &TimeBaseInit); 
+	TimeBaseInit.TIM_ClockDivision 	= TIM_CKD_DIV1;
+  TIM_TimeBaseInit(TIM2, &TimeBaseInit);
 
 	TIM_SelectOutputTrigger(TIM2, TIM_TRGOSource_OC2Ref);
 	TIM_CCxCmd(TIM2, TIM_Channel_2, TIM_CCx_Enable);
-	TIM_SetCompare2(TIM2, 1);	
+	TIM_SetCompare2(TIM2, 1);
 	TIM2->CCMR1 |= TIM_CCMR1_OC2M;
-  TIM_Cmd(TIM2, ENABLE); 
-	
+  TIM_Cmd(TIM2, ENABLE);
+
 	//ADC Init
-	NVIC_SetPriority (ADC_IRQn, 1);  
-	
+	NVIC_SetPriority (ADC_IRQn, 1);
+
 	//ADC GPIO Init
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
 	memset(&GPIO_Init_user, 0, sizeof(GPIO_Init_user));
 	GPIO_Init_user.GPIO_Pin 	= GPIO_Pin_0|GPIO_Pin_1;
 	GPIO_Init_user.GPIO_Mode 	= GPIO_Mode_AN; //Analog mode
-	GPIO_Init(GPIOA, & GPIO_Init_user);	
-	
+	GPIO_Init(GPIOA, & GPIO_Init_user);
+
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC2, ENABLE);
-	
+
 	ADC_StructInit(&ADC_InitType);
 	ADC_InitType.ADC_ContinuousConvMode 	= DISABLE;
 	ADC_InitType.ADC_DataAlign 						= ADC_DataAlign_Right;
@@ -360,25 +361,25 @@ void mADC_init(void)
 	ADC_InitType.ADC_ScanConvMode 				= DISABLE;
 
 	ADC_Init(ADC1, &ADC_InitType);
-	ADC_Init(ADC2, &ADC_InitType);	
+	ADC_Init(ADC2, &ADC_InitType);
 	ADC_RegularChannelConfig(ADC1, ADC_Channel_0 ,1, ADC_SampleTime_480Cycles);
 	ADC_RegularChannelConfig(ADC2, ADC_Channel_1 ,1, ADC_SampleTime_480Cycles);
-	
+
 	//ADC interrupts init
 	nvicStructure.NVIC_IRQChannel = ADC_IRQn;
 	nvicStructure.NVIC_IRQChannelPreemptionPriority = 1;
 	nvicStructure.NVIC_IRQChannelSubPriority = 0;
 	nvicStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvicStructure);
-	
+
 	ADC_POT_sel_cnt = 0;
 	ADC_POTS_selector_Ch(0);
-	
+
 	NVIC_EnableIRQ(ADC_IRQn);
 	ADC_ITConfig(ADC1, ADC_IT_EOC, ENABLE);
 	ADC_ITConfig(ADC2, ADC_IT_EOC, ENABLE);
-	ADC_Cmd(ADC1, ENABLE);	
-	ADC_Cmd(ADC2, ENABLE);	
+	ADC_Cmd(ADC1, ENABLE);
+	ADC_Cmd(ADC2, ENABLE);
 };
 
 
@@ -399,13 +400,13 @@ void mInterruptInit(void)
 	GPIO_InitTypeDef mGPIO;
 	EXTI_InitTypeDef mInt;
 	NVIC_InitTypeDef NVIC_InitStructure;
-	
+
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
-	
+
 	mGPIO.GPIO_Mode = GPIO_Mode_IN;
 	mGPIO.GPIO_Pin = GPIO_Pin_0|GPIO_Pin_1|GPIO_Pin_5|GPIO_Pin_6|GPIO_Pin_7|GPIO_Pin_8;
 	mGPIO.GPIO_PuPd = GPIO_PuPd_NOPULL;
-	mGPIO.GPIO_Speed = GPIO_Speed_100MHz;	
+	mGPIO.GPIO_Speed = GPIO_Speed_100MHz;
 	GPIO_Init(GPIOB, &mGPIO);
 
 	SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOB, GPIO_PinSource0);
@@ -415,38 +416,38 @@ void mInterruptInit(void)
 	SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOB, GPIO_PinSource7);
 	SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOB, GPIO_PinSource8);
 
-	
+
 	//START-STOP LINE INIT Interrupt
 	EXTI_DeInit();
 	mInt.EXTI_Line = EXTI_Line0|EXTI_Line1|EXTI_Line5|EXTI_Line6|EXTI_Line7|EXTI_Line8;
 	mInt.EXTI_Mode = EXTI_Mode_Interrupt;
 	mInt.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
-	mInt.EXTI_LineCmd = ENABLE;	
+	mInt.EXTI_LineCmd = ENABLE;
 	EXTI_Init(&mInt);
-	
-	NVIC_InitStructure.NVIC_IRQChannel = EXTI0_IRQn; 						
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE; 
+
+	NVIC_InitStructure.NVIC_IRQChannel = EXTI0_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
-	
-	NVIC_InitStructure.NVIC_IRQChannel = EXTI1_IRQn; 						
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE; 
+
+	NVIC_InitStructure.NVIC_IRQChannel = EXTI1_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
-	
-	NVIC_InitStructure.NVIC_IRQChannel = EXTI9_5_IRQn; 						
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00; 
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE; 
+
+	NVIC_InitStructure.NVIC_IRQChannel = EXTI9_5_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority 	= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority 				= 0x00;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
-	
-	EXTI_ClearITPendingBit(EXTI_Line0);	
-	EXTI_ClearITPendingBit(EXTI_Line1);	
-	EXTI_ClearITPendingBit(EXTI_Line5);	
-	EXTI_ClearITPendingBit(EXTI_Line6);	
-	EXTI_ClearITPendingBit(EXTI_Line7);	
+
+	EXTI_ClearITPendingBit(EXTI_Line0);
+	EXTI_ClearITPendingBit(EXTI_Line1);
+	EXTI_ClearITPendingBit(EXTI_Line5);
+	EXTI_ClearITPendingBit(EXTI_Line6);
+	EXTI_ClearITPendingBit(EXTI_Line7);
 	EXTI_ClearITPendingBit(EXTI_Line8);
 };
 
@@ -455,63 +456,63 @@ void mInterruptInit(void)
 //1 SECTION
 void EXTI0_IRQHandler()
 {
-	if ( !(GPIOB->IDR & GPIO_IDR_IDR_0) && 
+	if ( !(GPIOB->IDR & GPIO_IDR_IDR_0) &&
 		(gSequencerMode_1 != SEQUENCER_MODE_WAIT && gSequencerMode_1 != SEQUENCER_MODE_WAIT_HI_Z && gSequencerMode_1 != SEQUENCER_MODE_STAY_HI_Z)
 	) {
 		gPrevSequencerMode_1 = SEQUENCER_MODE_RUN;
-		gSequencerMode_1 = SEQUENCER_MODE_STOP;	
-		
+		gSequencerMode_1 = SEQUENCER_MODE_STOP;
+
 		DisplayUpdateFlags.b.MainDisplay 	= 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-	
-	EXTI_ClearITPendingBit(EXTI_Line0);	
+
+	EXTI_ClearITPendingBit(EXTI_Line0);
 };
 
 
 /*
-	Init timer for start pulse (section 1) duration measurement 
+	Init timer for start pulse (section 1) duration measurement
 */
 void InitStart_1_SignalTimer()
 {
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE);
-	
+
 	TIM3->PSC = STEP_TIMER_PRESCALER;
 	TIM3->ARR = START_TIMER_SUSTAIN;
 	TIM3->CNT = 0;
 	TIM3->DIER = TIM_DIER_UIE;
 	TIM3->CR1 |= TIM_CR1_CEN;
-	
-	NVIC_EnableIRQ(TIM3_IRQn);	
+
+	NVIC_EnableIRQ(TIM3_IRQn);
 };
 
 /*
-	Init timer for start pulse (section 2) duration measurement 
+	Init timer for start pulse (section 2) duration measurement
 */
 void InitStart_2_SignalTimer()
 {
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM7, ENABLE);
-	
+
 	TIM7->PSC = STEP_TIMER_PRESCALER;
 	TIM7->ARR = START_TIMER_SUSTAIN;
 	TIM7->CNT = 0;
 	TIM7->DIER = TIM_DIER_UIE;
 	TIM7->CR1 |= TIM_CR1_CEN;
-	
-	NVIC_EnableIRQ(TIM7_IRQn);	
+
+	NVIC_EnableIRQ(TIM7_IRQn);
 };
 
 void InitClear_Timer()
 {
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM6, ENABLE);
-	
+
 	TIM6->PSC = 21000;
 	TIM6->ARR = 200;
 	TIM6->CNT = 0;
 	TIM6->DIER = TIM_DIER_UIE;
 	TIM6->CR1 |= TIM_CR1_CEN;
-	
-	NVIC_EnableIRQ(TIM6_DAC_IRQn);	
+
+	NVIC_EnableIRQ(TIM6_DAC_IRQn);
 	TIM_ITConfig(TIM6, TIM_IT_Update, ENABLE);
 };
 
@@ -520,17 +521,17 @@ void InitClear_Timer()
 void EXTI1_IRQHandler()
 {
 	//if we are not in wait condition then stop the sequenser
-	if ( !(GPIOB->IDR & GPIO_IDR_IDR_1)  && 
+	if ( !(GPIOB->IDR & GPIO_IDR_IDR_1)  &&
 		(gSequencerMode_2 != SEQUENCER_MODE_WAIT && gSequencerMode_2 != SEQUENCER_MODE_WAIT_HI_Z && gSequencerMode_2 != SEQUENCER_MODE_STAY_HI_Z)
 	) {
 		gPrevSequencerMode_2 = SEQUENCER_MODE_RUN;
-		gSequencerMode_2 = SEQUENCER_MODE_STOP;	
-		
+		gSequencerMode_2 = SEQUENCER_MODE_STOP;
+
 		//Update both
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-	
+
 	EXTI_ClearITPendingBit(EXTI_Line1);
 };
 
@@ -540,8 +541,8 @@ void EXTI9_5_IRQHandler()
 {
 	//1 Section
 	//1 LH
-	if (EXTI->PR & (1<<8)) {	 
-		  
+	if (EXTI->PR & (1<<8)) {
+
 		if((gSequencerMode_1 != SEQUENCER_MODE_STAY_HI_Z && gSequencerMode_1 != SEQUENCER_MODE_WAIT_HI_Z) && (gSequencerMode_1 != SEQUENCER_MODE_WAIT) && (gSequencerMode_1 != SEQUENCER_MODE_RUN))
 		{
 			gSequencerMode_1 = SEQUENCER_MODE_RUN;
@@ -551,14 +552,14 @@ void EXTI9_5_IRQHandler()
 		{
 			InitStart_1_SignalTimer();
 		}
-		
+
 		EXTI_ClearITPendingBit(EXTI_Line8);
 	};
-	 
+
 	 //2 Section
-	 
+
 	 if (EXTI->PR & (1<<6)) {
-		 
+
 		 if((gSequencerMode_2 != SEQUENCER_MODE_STAY_HI_Z && gSequencerMode_2 != SEQUENCER_MODE_WAIT_HI_Z) && (gSequencerMode_2 != SEQUENCER_MODE_WAIT) && (gSequencerMode_2 != SEQUENCER_MODE_RUN))
 		{
 			gSequencerMode_2 = SEQUENCER_MODE_RUN;
@@ -568,61 +569,61 @@ void EXTI9_5_IRQHandler()
 		{
 			InitStart_2_SignalTimer();
 		}
-		
+
 		EXTI_ClearITPendingBit(EXTI_Line6);
 	 };
-	 
+
 	 //Strobe jack A
 	 	if (EXTI->PR & (1<<5)) {
-		 
+
 			gSequenceStepNumber_1 = (unsigned int) (pots_step[0]-1);
-			
+
 			if ( gDisplayMode == DISPLAY_MODE_VIEW_1 ) {
 				DisplayUpdateFlags.b.MainDisplay = 1;
 				DisplayUpdateFlags.b.StepsDisplay = 1;
 			};
-			
+
 				PULSE_LED_I_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_I_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_I_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM14, ENABLE);
 				TIM_SetCounter(TIM14, 0x00);
-				
+
 		EXTI_ClearITPendingBit(EXTI_Line5);
 	 };
-		
+
 	 	 //Strobe jack B
 	 	if (EXTI->PR & (1<<7)) {
-		 
+
 		gSequenceStepNumber_2 = (unsigned int) (pots_step[1]-1);
 		if ( gDisplayMode == DISPLAY_MODE_VIEW_2 ) {
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-			
+
 				PULSE_LED_II_ALL_ON;
-				
+
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse1) {
 					PULSE_LED_II_1_ON;
 				};
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse2) {
 					PULSE_LED_II_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM8, ENABLE);
 			TIM_SetCounter(TIM8, 0x00);
-				
+
 		EXTI_ClearITPendingBit(EXTI_Line7);
 	 };
-	 
+
 	DisplayUpdateFlags.b.MainDisplay = 1;
-	DisplayUpdateFlags.b.StepsDisplay = 1;	 
+	DisplayUpdateFlags.b.StepsDisplay = 1;
 };
 
 
@@ -631,7 +632,7 @@ void EXTI9_5_IRQHandler()
 	Save current sequence to memory
 */
 unsigned char SaveSequence(unsigned char SequenceCell)
-{	
+{
 	ADCPause();
 	if(!Is_Expander_Present())
 	{
@@ -641,7 +642,7 @@ unsigned char SaveSequence(unsigned char SequenceCell)
 	else
 	{
 		CAT25512_write_block((SequenceCell+32)*sizeof(Steps), (unsigned char *) Steps[0], sizeof(Steps[0]));
-		CAT25512_write_block((SequenceCell+32)*sizeof(Steps)+sizeof(Steps[0]), (unsigned char *) Steps[1], sizeof(Steps[1]));		
+		CAT25512_write_block((SequenceCell+32)*sizeof(Steps)+sizeof(Steps[0]), (unsigned char *) Steps[1], sizeof(Steps[1]));
 	}
 	mADC_init();
 	return 0;
@@ -658,12 +659,12 @@ void LoadSequence(unsigned char SequenceCell)
 		CAT25512_read_block(bank*SequenceCell*sizeof(Steps), (unsigned char *) Steps[0], sizeof(Steps[0]));
 		CAT25512_read_block(bank*SequenceCell*sizeof(Steps)+sizeof(Steps[0]), (unsigned char *) Steps[1], sizeof(Steps[1]));
 	}
-	else 
+	else
 	{
 		CAT25512_read_block((SequenceCell+32)*sizeof(Steps), (unsigned char *) Steps[0], sizeof(Steps[0]));
 		CAT25512_read_block((SequenceCell+32)*sizeof(Steps)+sizeof(Steps[0]), (unsigned char *) Steps[1], sizeof(Steps[1]));
 	}
-	
+
 	//Block sliders scanning while voltages from slider and preset aren't equal
 	if (gDipConfig.b.SAVE_V_LEVEL == 1) {
 		for(cnt=0; cnt<16; cnt++)
@@ -671,17 +672,17 @@ void LoadSequence(unsigned char SequenceCell)
 			Steps[0][cnt].b.WaitVoltageSlider = 1;
 			Steps[0][cnt].b.WaitTimeSlider = 1;
 			Steps[1][cnt].b.WaitVoltageSlider = 1;
-			Steps[1][cnt].b.WaitTimeSlider = 1;	
+			Steps[1][cnt].b.WaitTimeSlider = 1;
 			Steps[0][cnt+16].b.WaitVoltageSlider = 1;
 			Steps[0][cnt+16].b.WaitTimeSlider = 1;
 			Steps[1][cnt+16].b.WaitVoltageSlider = 1;
-			Steps[1][cnt+16].b.WaitTimeSlider = 1;				
-		};		
+			Steps[1][cnt+16].b.WaitTimeSlider = 1;
+		};
 	};
-	
+
 	gSequencerMode_1 = SEQUENCER_MODE_STOP;
 	gSequencerMode_2 = SEQUENCER_MODE_STOP;
-	
+
 	mADC_init();
 };
 
@@ -698,33 +699,33 @@ unsigned long int GetStepWidth(unsigned char _Section, unsigned char _StepNum)
 	unsigned char ext_ban_num = 0;
 
 	if (Steps[_Section][_StepNum].b.TimeSource) {
-		
+
 		//Step time is set externally
 		ext_ban_num = Steps[_Section][_StepNum].b.TLevel/EXT_VOLTAGE_STEP_SELECT;
 		if(ext_ban_num > 3) ext_ban_num = 3;
-		
+
 		time_level = AddData[ext_ban_num]*(4095.0f/((float)CalConstants[ext_ban_num]));
 	} else {
 		//Step time is set on panel
 		time_level = (Steps[_Section][_StepNum].b.TLevel + 1);
 	};
-	
+
 	if (Steps[_Section][_StepNum].b.TimeRange_p03 == 1) {
 		ret_val = (unsigned long int) ((((float) time_level * 112)/4095) +8);
 	};
-	
+
 	if (Steps[_Section][_StepNum].b.TimeRange_p3 == 1) {
 		ret_val = (unsigned long int) ((((float) time_level * 1120)/4095) +80);
 	};
-	
+
 	if (Steps[_Section][_StepNum].b.TimeRange_3 == 1) {
 		ret_val = (unsigned long int) ((((float) time_level * 11200)/4095) +800);
 	};
-	
+
 	if (Steps[_Section][_StepNum].b.TimeRange_30 == 1) {
 		ret_val = (unsigned long int) ((((float) time_level * 112000)/4095) +8000);
 	};
-	
+
 	return ret_val;
 };
 
@@ -732,10 +733,10 @@ unsigned long int GetStepWidth(unsigned char _Section, unsigned char _StepNum)
 /*
 	Return the voltage for step number _StepNum in section _Section
 */
-	#define MAX_DAC_VALUE			0xFFF 	
-	#define FULL_RANGE_STEPS	60		
-	#define QUANTIZE_DIVIDER	MAX_DAC_VALUE/FULL_RANGE_STEPS 
-	
+	#define MAX_DAC_VALUE			0xFFF
+	#define FULL_RANGE_STEPS	60
+	#define QUANTIZE_DIVIDER	MAX_DAC_VALUE/FULL_RANGE_STEPS
+
 unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 {
 	unsigned int ret_val = 0;
@@ -746,16 +747,26 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 		//Step voltage is set externally
 		ext_ban_num = Steps[_Section][_StepNum].b.VLevel/EXT_VOLTAGE_STEP_SELECT;
 		if(ext_ban_num > 3) ext_ban_num = 3;
-		
+
 		voltage_level = AddData[ext_ban_num]*(4095.0f/((float)CalConstants[ext_ban_num]));
 	} else {
 		//Step voltage is set on panel
 		voltage_level = Steps[_Section][_StepNum].b.VLevel;
 	};
-	
+
+	// Round voltage level to 4 decimal places of precision
+	// We multiply the number by 10000 to raise the whole number value of voltage
+	// to include the first 4 decimal places, then remove all remaining decimal places,
+	// then divide again. C is weird.
+	// Ultimately when converting a voltage value to binary and then reinterpreting it
+	// as a numeric value there is a degree of variance (computers aren't perfect)
+	// This reigns in that variance while still leaving enough wiggle room for solid
+	// microtonality
+	voltage_level = floor(10000*voltage_level)/10000
+
 	if(voltage_level > 4095) voltage_level = 4095;
 
-	if (Steps[_Section][_StepNum].b.FullRange) {		
+	if (Steps[_Section][_StepNum].b.FullRange) {
 		ret_val = voltage_level;
 		// if quantization mode is on
 		if (Steps[_Section][_StepNum].b.Quantize) {
@@ -764,8 +775,8 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 			ret_val = ret_val * (12*divider);
 		};
 	};
-	
-	if (Steps[_Section][_StepNum].b.Voltage0) {	
+
+	if (Steps[_Section][_StepNum].b.Voltage0) {
 		ret_val = (voltage_level/divider);
 		if (Steps[_Section][_StepNum].b.Quantize) {
 
@@ -773,8 +784,8 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 			ret_val = ret_val * (offset/12);
 		};
 	};
-	
-	if (Steps[_Section][_StepNum].b.Voltage2) {		
+
+	if (Steps[_Section][_StepNum].b.Voltage2) {
 		ret_val = (voltage_level/divider);
 		if (Steps[_Section][_StepNum].b.Quantize) {
 			ret_val =  (ret_val / (offset/12)) ;
@@ -782,8 +793,8 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 		};
 		ret_val +=offset;
 	};
-	
-	if (Steps[_Section][_StepNum].b.Voltage4) {		
+
+	if (Steps[_Section][_StepNum].b.Voltage4) {
 		ret_val = (voltage_level/divider);
 		if (Steps[_Section][_StepNum].b.Quantize) {
 			ret_val =  (ret_val / (offset/12)) ;
@@ -791,8 +802,8 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 		};
 		ret_val +=offset*2;
 	};
-	
-	if (Steps[_Section][_StepNum].b.Voltage6) {		
+
+	if (Steps[_Section][_StepNum].b.Voltage6) {
 		ret_val = (voltage_level/divider);
 		if (Steps[_Section][_StepNum].b.Quantize) {
 			ret_val =  (ret_val / (offset/12)) ;
@@ -800,8 +811,8 @@ unsigned int GetStepVoltage(unsigned char _Section, unsigned char _StepNum)
 		};
 		ret_val +=offset*3;
 	};
-	
-	if (Steps[_Section][_StepNum].b.Voltage8) {		
+
+	if (Steps[_Section][_StepNum].b.Voltage8) {
 		ret_val = (voltage_level/divider);
 		if (Steps[_Section][_StepNum].b.Quantize) {
 			ret_val =  (ret_val / (offset/12)) ;
@@ -825,15 +836,15 @@ unsigned char GetNextStep(unsigned char _Section, unsigned char _StepNum)
 	unsigned char max_step;
 
 	if(Is_Expander_Present()) max_step = 31;
-	else 
+	else
 	{
 		max_step = 15;
 		if(_StepNum > 15) return 0;
 	}
-	
+
 	isLastStage = Steps[_Section][_StepNum].b.CycleLast;
-	
-	if (isLastStage != 0) {      
+
+	if (isLastStage != 0) {
 		//Current step is last step
 		for(tmp = 0; tmp <= max_step; tmp++)
 		{
@@ -853,9 +864,9 @@ unsigned char GetNextStep(unsigned char _Section, unsigned char _StepNum)
 			  isLastStage = 0;
 			};
 		};
-    } 
+    }
 
-    if (isLastStage == 0) {		
+    if (isLastStage == 0) {
 		if ( _StepNum >= max_step ) {
 			ret_val = 0;
 		} else {
@@ -875,18 +886,18 @@ void TIM4_IRQHandler()
 	unsigned long int StepWidth_1=0;
 	float deltaVoltage;
 	unsigned long CurStep;
-	
-	
+
+
 	/* Clear interrupt flag */
 	TIM4->SR = (uint16_t) ~TIM_IT_Update;
 
-	/* Calculate next step duration */		
+	/* Calculate next step duration */
 	StepWidth_1 = GetStepWidth(0, gSequenceStepNumber_1);
-					
-					
+
+
 		/* Calculate prescaler/multiplier*/
 		TIM4->PSC = (uint16_t) ((((((float) AddData[ADC_TIMEMULTIPLY_Ch_1])*3.5f)/CalConstants[ADC_TIMEMULTIPLY_Ch_1])+0.5f)*STEP_TIMER_PRESCALER);
-		
+
 
 		if (Steps[0][gSequenceStepNumber_1].b.Sloped) {
 			//Calculate the voltage in slope mode
@@ -901,8 +912,8 @@ void TIM4_IRQHandler()
 					deltaVoltage =  (float) (CurStep-PreviousStep) / StepWidth_1;
 					DAC_SetChannel1Data(DAC_Align_12b_R, PreviousStep + (unsigned int) (deltaVoltage*gStepWidth_1) );
 				};
-			}			
-			else 
+			}
+			else
 			{
 				DAC_SetChannel1Data(DAC_Align_12b_R, GetStepVoltage(0, gSequenceStepNumber_1));
 			}
@@ -910,15 +921,15 @@ void TIM4_IRQHandler()
 			//Calculate the voltage in not slope mode
 			DAC_SetChannel1Data(DAC_Align_12b_R, GetStepVoltage(0, gSequenceStepNumber_1));
 		};
-		
+
 			/*additional channels - ref and time*/
 			MAX5135_DAC_send(EXT_DAC_CH_0, Steps[0][gSequenceStepNumber_1].b.TLevel >> 2);
 			MAX5135_DAC_send(EXT_DAC_CH_1, 1023 - (unsigned int) (((double) 1023/ (double) StepWidth_1)*((double) gStepWidth_1)) );
-		
-		
-		/* Increment step counter */ 
-		if ( (gSequencerMode_1 == SEQUENCER_MODE_RUN ) || 
-			(	(gSequencerMode_1 == SEQUENCER_MODE_ADVANCE) 	) 
+
+
+		/* Increment step counter */
+		if ( (gSequencerMode_1 == SEQUENCER_MODE_RUN ) ||
+			(	(gSequencerMode_1 == SEQUENCER_MODE_ADVANCE) 	)
 		)
 		{
 			gStepWidth_1++;
@@ -926,44 +937,44 @@ void TIM4_IRQHandler()
 
 		if ((gStepWidth_1 < StepWidth_1)) {
 
-		} 
+		}
 		else
-		{		
-			//Calculate next step		
+		{
+			//Calculate next step
 			PreviousStep = GetStepVoltage(0, gSequenceStepNumber_1);
 
-			if ( (gSequencerMode_1 == SEQUENCER_MODE_ADVANCE)   ) { 
+			if ( (gSequencerMode_1 == SEQUENCER_MODE_ADVANCE)   ) {
 				gSequencerMode_1 = gPrevSequencerMode_1;
 			};
-						
+
 			if (Steps[0][gSequenceStepNumber_1].b.OpModeSTOP) {
 				gPrevSequencerMode_1 = gSequencerMode_1;
-				gSequencerMode_1 = SEQUENCER_MODE_STOP;				
+				gSequencerMode_1 = SEQUENCER_MODE_STOP;
 			};
-			
+
 			if ((Steps[0][gSequenceStepNumber_1].b.OpModeENABLE))  {
-				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 0)) 
+				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 0))
 				{
 				if(gSequencerMode_1 != SEQUENCER_MODE_WAIT_HI_Z)
-				{	
+				{
 					gPrevSequencerMode_1 = gSequencerMode_1;
 					gSequencerMode_1 = SEQUENCER_MODE_WAIT_HI_Z;
 				}
 				}
 			};
-				
+
 			if((Steps[0][gSequenceStepNumber_1].b.OpModeSUSTAIN))  {
-				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 1)) 
+				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 1))
 				{
 					if(gSequencerMode_1 != SEQUENCER_MODE_STAY_HI_Z)
-					{	
+					{
 						gPrevSequencerMode_1 = gSequencerMode_1;
 						gSequencerMode_1 = SEQUENCER_MODE_STAY_HI_Z;
 						InitStart_1_SignalTimer();
 					}
-				}	
+				}
 			};
-							
+
 			if ( (!(Steps[0][gSequenceStepNumber_1].b.OpModeSTOP)) &&
 					(!(Steps[0][gSequenceStepNumber_1].b.OpModeENABLE)) &&
 					(!(Steps[0][gSequenceStepNumber_1].b.OpModeSUSTAIN)) ) {
@@ -973,41 +984,41 @@ void TIM4_IRQHandler()
 			gStepWidth_1 = 0;
 
 			/* Generate pulse at the end of every step */
-			if (gSequencerMode_1 == SEQUENCER_MODE_RUN) {		
+			if (gSequencerMode_1 == SEQUENCER_MODE_RUN) {
 				gSequenceStepNumber_1 = GetNextStep(0, gSequenceStepNumber_1);
 				PULSE_LED_I_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_I_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_I_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM14, ENABLE);
 				TIM_SetCounter(TIM14, 0x00);
 			};
 		};
-	
+
 	if (gSequencerMode_1 == SEQUENCER_MODE_WAIT) {
 		if(gSequenceStepNumber_1 != (unsigned int) (pots_step[0]-1))
 		{
-			gSequenceStepNumber_1 = (unsigned int) (pots_step[0]-1); 
+			gSequenceStepNumber_1 = (unsigned int) (pots_step[0]-1);
 			DAC_SetChannel1Data(DAC_Align_12b_R, GetStepVoltage(0, gSequenceStepNumber_1));
-			
+
 			PULSE_LED_I_ALL_ON;
-			
+
 			if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 				PULSE_LED_I_1_ON;
 			};
 			if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 				PULSE_LED_I_2_ON;
-			};	
-						
+			};
+
 			TIM_Cmd(TIM14, ENABLE);
 			TIM_SetCounter(TIM14, 0x00);
 		}
-	};	
+	};
 
 	if (gSequencerMode_1 == SEQUENCER_MODE_WAIT_STROBE) {
 
@@ -1015,12 +1026,12 @@ void TIM4_IRQHandler()
 			DAC_SetChannel1Data(DAC_Align_12b_R, GetStepVoltage(0, gSequenceStepNumber_1));
 		gSequencerMode_1 = gPrevSequencerMode_1;
 	}
-		
+
 	if ( gDisplayMode == DISPLAY_MODE_VIEW_1 ) {
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
-	};		
-	
+	};
+
 		return;
 };
 
@@ -1029,21 +1040,21 @@ void TIM4_IRQHandler()
 */
 void TIM5_IRQHandler()
 {
-	unsigned long int StepWidth_2=0;	
+	unsigned long int StepWidth_2=0;
 	float deltaVoltage;
 	unsigned long CurStep;
 
 	/* Clear interrupt flag */
 	TIM5->SR = (uint16_t) ~TIM_IT_Update;
-	
-	/* Calculate next step duration */	
-	
+
+	/* Calculate next step duration */
+
 		/* Calculate next step duration */
 		StepWidth_2 = GetStepWidth(1, gSequenceStepNumber_2);
 
 		/* Calculate prescaler/multiplier*/
 		TIM5->PSC = (uint16_t) (((((AddData[ADC_TIMEMULTIPLY_Ch_2])*3.5)/CalConstants[ADC_TIMEMULTIPLY_Ch_2])+0.5)*STEP_TIMER_PRESCALER);
-		
+
 		if (Steps[1][gSequenceStepNumber_2].b.Sloped) {
 			//Calculate the voltage in slope mode
 			CurStep = GetStepVoltage(1, gSequenceStepNumber_2);
@@ -1056,13 +1067,13 @@ void TIM5_IRQHandler()
 				if (CurStep>PreviousStep_2) {
 					deltaVoltage =  (float) (CurStep-PreviousStep_2) / StepWidth_2;
 					DAC_SetChannel2Data(DAC_Align_12b_R, PreviousStep_2 + (unsigned int) (deltaVoltage*gStepWidth_2) );
-				};	
+				};
 			}
 			else
 			{
 				DAC_SetChannel2Data(DAC_Align_12b_R, GetStepVoltage(1, gSequenceStepNumber_2));
 			}
-			
+
 		} else {
 			//Calculate the voltage in not slope mode
 			DAC_SetChannel2Data(DAC_Align_12b_R, GetStepVoltage(1, gSequenceStepNumber_2));
@@ -1079,40 +1090,40 @@ void TIM5_IRQHandler()
 
 		if ((gStepWidth_2 < StepWidth_2)) {
 		} else {
-			PreviousStep_2 = GetStepVoltage(1, gSequenceStepNumber_2);	
-			//Calculate next step		
-			if((gSequencerMode_2 == SEQUENCER_MODE_ADVANCE)) { 
+			PreviousStep_2 = GetStepVoltage(1, gSequenceStepNumber_2);
+			//Calculate next step
+			if((gSequencerMode_2 == SEQUENCER_MODE_ADVANCE)) {
 				gSequencerMode_2 = gPrevSequencerMode_2;
 			};
-			
+
 			if (Steps[1][gSequenceStepNumber_2].b.OpModeSTOP) {
 				gPrevSequencerMode_2 = gSequencerMode_2;
-				gSequencerMode_2 = SEQUENCER_MODE_STOP;				
+				gSequencerMode_2 = SEQUENCER_MODE_STOP;
 			};
-			
+
 			if ( (Steps[1][gSequenceStepNumber_2].b.OpModeENABLE))  {
-				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 0)) 
+				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 0))
 				{
 					if(gSequencerMode_2 != SEQUENCER_MODE_WAIT_HI_Z)
-					{	
+					{
 						gPrevSequencerMode_2 = gSequencerMode_2;
 						gSequencerMode_2 = SEQUENCER_MODE_WAIT_HI_Z;
 					}
 				}
 		};
-				
+
 			if ( (Steps[1][gSequenceStepNumber_2].b.OpModeSUSTAIN)) {
-				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 1)) 
+				if( (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 1))
 				{
 					if(gSequencerMode_2 != SEQUENCER_MODE_STAY_HI_Z)
-					{	
+					{
 						gPrevSequencerMode_2 = gSequencerMode_2;
 						gSequencerMode_2 = SEQUENCER_MODE_STAY_HI_Z;
 						InitStart_2_SignalTimer();
 					}
 				}
 			};
-				
+
 			if ( (!(Steps[1][gSequenceStepNumber_2].b.OpModeSTOP)) &&
 					(!(Steps[1][gSequenceStepNumber_2].b.OpModeENABLE)) &&
 					(!(Steps[1][gSequenceStepNumber_2].b.OpModeSUSTAIN)) ) {
@@ -1123,28 +1134,28 @@ void TIM5_IRQHandler()
 			/* Generate pulse at the end of every step */
 			if (gSequencerMode_2 == SEQUENCER_MODE_RUN) {
 					gSequenceStepNumber_2 = GetNextStep(1, gSequenceStepNumber_2);
-				
+
 				PULSE_LED_II_ALL_ON;
-				
+
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse1) {
 					PULSE_LED_II_1_ON;
 				};
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse2) {
 					PULSE_LED_II_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM8, ENABLE);
 				TIM_SetCounter(TIM8, 0x00);
-			}; 
+			};
 		};
-	
+
 
 	if (gSequencerMode_2 == SEQUENCER_MODE_WAIT) {
 		if(gSequenceStepNumber_2 != (unsigned int)(pots_step[1]-1))
 		{
 			gSequenceStepNumber_2 = (unsigned int)(pots_step[1]-1);
 			DAC_SetChannel2Data(DAC_Align_12b_R, GetStepVoltage(1, gSequenceStepNumber_2));
-			
+
 			PULSE_LED_II_ALL_ON;
 
 			if (Steps[1][gSequenceStepNumber_2].b.OutputPulse1) {
@@ -1152,13 +1163,13 @@ void TIM5_IRQHandler()
 			};
 			if (Steps[1][gSequenceStepNumber_2].b.OutputPulse2) {
 				PULSE_LED_II_2_ON;
-			};	
+			};
 
 			TIM_Cmd(TIM8, ENABLE);
 			TIM_SetCounter(TIM8, 0x00);
 		}
-	};	
-	
+	};
+
 		if (gSequencerMode_2 == SEQUENCER_MODE_WAIT_STROBE) {
 
 			gSequenceStepNumber_2 = (unsigned int)(pots_step[1]-1);
@@ -1166,12 +1177,12 @@ void TIM5_IRQHandler()
 
 		gSequencerMode_2 = gPrevSequencerMode_2;
 	}
-	
-	
+
+
 	if ( gDisplayMode == DISPLAY_MODE_VIEW_2 ) {
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
-	};	
+	};
 		return;
 };
 
@@ -1183,7 +1194,7 @@ void mTimersInit(void)
 {
 	TIM_TimeBaseInitTypeDef myTimer;
 	NVIC_InitTypeDef nvicStructure;
-	
+
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM4, ENABLE);
 
 	TIM_TimeBaseStructInit(&myTimer);
@@ -1191,71 +1202,71 @@ void mTimersInit(void)
 	myTimer.TIM_Period = 1;
 	myTimer.TIM_ClockDivision = TIM_CKD_DIV1;
 	myTimer.TIM_CounterMode = TIM_CounterMode_Up;
-	
-	TIM_TimeBaseInit(TIM4, &myTimer);	
+
+	TIM_TimeBaseInit(TIM4, &myTimer);
 	TIM_ARRPreloadConfig(TIM4, ENABLE);
 	TIM_Cmd(TIM4, ENABLE);
-	
+
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM5, ENABLE);
 	TIM_TimeBaseInit(TIM5, &myTimer);
 	TIM_ARRPreloadConfig(TIM5, ENABLE);
 	TIM_Cmd(TIM5, ENABLE);
-	
+
 	TIM_ITConfig(TIM4, TIM_IT_Update, ENABLE);
 	TIM_ITConfig(TIM5, TIM_IT_Update, ENABLE);
-	
-	
-	
+
+
+
 	nvicStructure.NVIC_IRQChannel = TIM4_IRQn;
 	nvicStructure.NVIC_IRQChannelPreemptionPriority = 0;
 	nvicStructure.NVIC_IRQChannelSubPriority = 0;
 	nvicStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvicStructure);
-	
+
 	nvicStructure.NVIC_IRQChannel = TIM5_IRQn;
 	nvicStructure.NVIC_IRQChannelPreemptionPriority = 0;
 	nvicStructure.NVIC_IRQChannelSubPriority = 0;
 	nvicStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvicStructure);
-	
+
 	NVIC_SetPriority (TIM4_IRQn, 0);
 	NVIC_SetPriority (TIM5_IRQn, 0);
-	
+
 	SCB->AIRCR = AIRCR_VECTKEY_MASK | NVIC_PriorityGroup_0;
-	
+
 	gStepWidth_1 = 8;
 	gStepWidth_2 = 8;
 	gFullStepWidth_1 = 8;
 	gFullStepWidth_2 = 8;
-	
+
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM14, ENABLE);
-	
+
 	TIM_TimeBaseStructInit(&myTimer);
 	myTimer.TIM_Prescaler = 210;
 	myTimer.TIM_Period = 320;
 	myTimer.TIM_ClockDivision = TIM_CKD_DIV1;
 	myTimer.TIM_CounterMode = TIM_CounterMode_Up;
-	
-	TIM_TimeBaseInit(TIM14, &myTimer);	
-	
+
+	TIM_TimeBaseInit(TIM14, &myTimer);
+
 	TIM_Cmd(TIM14, DISABLE);
 	TIM_ITConfig(TIM14, TIM_IT_Update, ENABLE);
 	NVIC_EnableIRQ(TIM8_TRG_COM_TIM14_IRQn);
-	
+
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM8, ENABLE);
-	
+
 	TIM_TimeBaseStructInit(&myTimer);
 	myTimer.TIM_Prescaler = 210;
 	myTimer.TIM_Period = 640;
 	myTimer.TIM_ClockDivision = TIM_CKD_DIV1;
 	myTimer.TIM_CounterMode = TIM_CounterMode_Up;
-	
-	TIM_TimeBaseInit(TIM8, &myTimer);	
-	
+
+	TIM_TimeBaseInit(TIM8, &myTimer);
+
 	TIM_Cmd(TIM8, DISABLE);
 	TIM_ITConfig(TIM8, TIM_IT_Update, ENABLE);
 	NVIC_EnableIRQ(TIM8_UP_TIM13_IRQn);
-	
+
 };
 
 //Turn off pulses
@@ -1269,7 +1280,7 @@ void TIM8_UP_TIM13_IRQHandler(void)
 		PULSE_LED_II_1_OFF;
 		PULSE_LED_II_2_OFF;
 		TIM_ClearITPendingBit(TIM8, TIM_IT_Update);
-	}		
+	}
 }
 
 //Section 2
@@ -1282,32 +1293,32 @@ void TIM8_TRG_COM_TIM14_IRQHandler(void)
 		PULSE_LED_I_1_OFF;
 		PULSE_LED_I_2_OFF;
 		TIM_ClearITPendingBit(TIM14, TIM_IT_Update);
-	}		
+	}
 }
 
 //Timer Interrupt handler for start switch scan
 //Section 1
 void TIM3_IRQHandler()
 {
-	TIM3->SR = (uint16_t) ~TIM_IT_Update;	
-	
-	if ( (gSequencerMode_1 == SEQUENCER_MODE_WAIT_HI_Z) 
+	TIM3->SR = (uint16_t) ~TIM_IT_Update;
+
+	if ( (gSequencerMode_1 == SEQUENCER_MODE_WAIT_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 0) ) {
 	}
-	else if((gSequencerMode_1 == SEQUENCER_MODE_WAIT_HI_Z) 
+	else if((gSequencerMode_1 == SEQUENCER_MODE_WAIT_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 1))
 	{
 		gSequencerMode_1 = SEQUENCER_MODE_RUN;
 		gSequenceStepNumber_1 = GetNextStep(0, gSequenceStepNumber_1);
 		TIM3->CR1 &= ~TIM_CR1_CEN;
 	}
-	
-	if((gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z) 
+
+	if((gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 1))
 	{
 
 	}
-	else if((gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z) 
+	else if((gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_8) == 0))
 	{
 		gSequencerMode_1 = SEQUENCER_MODE_RUN;
@@ -1319,24 +1330,24 @@ void TIM3_IRQHandler()
 //Section 2
 void TIM7_IRQHandler()
 {
-	TIM7->SR = (uint16_t) ~TIM_IT_Update;	
-	
-	if ( (gSequencerMode_2 == SEQUENCER_MODE_WAIT_HI_Z) 
+	TIM7->SR = (uint16_t) ~TIM_IT_Update;
+
+	if ( (gSequencerMode_2 == SEQUENCER_MODE_WAIT_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 0) ) {
 	}
-	else if((gSequencerMode_2 == SEQUENCER_MODE_WAIT_HI_Z) 
+	else if((gSequencerMode_2 == SEQUENCER_MODE_WAIT_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 1))
 	{
 		gSequencerMode_2 = SEQUENCER_MODE_RUN;
 		gSequenceStepNumber_2 = GetNextStep(1, gSequenceStepNumber_2);
 		TIM7->CR1 &= ~TIM_CR1_CEN;
 	}
-	
-	if((gSequencerMode_2 == SEQUENCER_MODE_STAY_HI_Z) 
+
+	if((gSequencerMode_2 == SEQUENCER_MODE_STAY_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 1))
 	{
 	}
-	else if((gSequencerMode_2 == SEQUENCER_MODE_STAY_HI_Z) 
+	else if((gSequencerMode_2 == SEQUENCER_MODE_STAY_HI_Z)
 			&& (GPIO_ReadInputDataBit(GPIOB, GPIO_Pin_6) == 0))
 	{
 		gSequencerMode_2 = SEQUENCER_MODE_RUN;
@@ -1352,13 +1363,13 @@ void TIM6_DAC_IRQHandler()
 	uButtons myButtons;
 	static uint8_t clear_counter1 = 0, clear_counter2 = 0;
 
-	TIM6->SR = (uint16_t) ~TIM_IT_Update;	
+	TIM6->SR = (uint16_t) ~TIM_IT_Update;
 
 	myButtons.value = GetButton();
 
 	if(clear_counter1 < 30 && clear_counter2 < 30)
 	{
-		if(!myButtons.b.ClearUp || !myButtons.b.ClearDown) 
+		if(!myButtons.b.ClearUp || !myButtons.b.ClearDown)
 		{
 			if(!myButtons.b.ClearUp) clear_counter1++;
 			else clear_counter1 = 0;
@@ -1390,19 +1401,19 @@ void TIM6_DAC_IRQHandler()
 
 		TIM_SetCounter(TIM6, 0x00);
 		TIM6->CR1 &= ~TIM_CR1_CEN;
-	
-		
-		
+
+
+
 		if(clear_counter1 == 30)
-		{		
+		{
 			//Clear section 1 state
-			
+
 			Steps[0][0].val[3] = 0x00;
 			Steps[0][0].val[4] = 0x00;
 			Steps[0][0].val[5] = 0x00;
 			Steps[0][0].b.TimeRange_p3 = 1;
 			Steps[0][0].b.FullRange = 1;
-			
+
 			for(i=0; i<16; i++)
 			{
 				Steps[0][i] = Steps[0][0];
@@ -1414,7 +1425,7 @@ void TIM6_DAC_IRQHandler()
 		else if(clear_counter2 == 30)
 		{
 			//Clear section 2 state
-			
+
 			Steps[1][0].val[3] = 0x00;
 			Steps[1][0].val[4] = 0x00;
 			Steps[1][0].val[5] = 0x00;
@@ -1428,13 +1439,13 @@ void TIM6_DAC_IRQHandler()
 			gSequencerMode_2 = SEQUENCER_MODE_STOP;
 			gSequenceStepNumber_2 = 0;
 		};
-		
+
 		clear_counter1 = 0;
 		clear_counter2 = 0;
-		
+
 		//If not in view mode switch in it
 		if (gDisplayMode == DISPLAY_MODE_LOAD_1 || gDisplayMode == DISPLAY_MODE_SAVE_1) gDisplayMode = DISPLAY_MODE_VIEW_1;
-		if (gDisplayMode == DISPLAY_MODE_LOAD_2 || gDisplayMode == DISPLAY_MODE_SAVE_2) gDisplayMode = DISPLAY_MODE_VIEW_2; 		
+		if (gDisplayMode == DISPLAY_MODE_LOAD_2 || gDisplayMode == DISPLAY_MODE_SAVE_2) gDisplayMode = DISPLAY_MODE_VIEW_2;
 	};
 };
 
@@ -1444,7 +1455,7 @@ Init GPIO for pulses generation
 void PulsesInit()
 {
 	GPIO_InitTypeDef GPIO_Pulses;
-	
+
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOB, ENABLE);
 	memset(&GPIO_Pulses, 0, sizeof(GPIO_Pulses));
 	GPIO_Pulses.GPIO_Pin 		= PULSE_LED_I_ALL|PULSE_LED_I_1|PULSE_LED_I_2;
@@ -1452,13 +1463,13 @@ void PulsesInit()
 	GPIO_Pulses.GPIO_OType	= GPIO_OType_PP;
 	GPIO_Pulses.GPIO_PuPd		= GPIO_PuPd_NOPULL;
 	GPIO_Pulses.GPIO_Speed	= GPIO_Speed_100MHz;
-	
+
 	GPIO_Init(GPIOB, &GPIO_Pulses);
-	
+
 	PULSE_LED_I_ALL_OFF;
 	PULSE_LED_I_1_OFF;
 	PULSE_LED_I_2_OFF;
-		
+
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
 	memset(&GPIO_Pulses, 0, sizeof(GPIO_Pulses));
 	GPIO_Pulses.GPIO_Pin 		= PULSE_LED_II_ALL|PULSE_LED_II_1|PULSE_LED_II_2;
@@ -1466,9 +1477,9 @@ void PulsesInit()
 	GPIO_Pulses.GPIO_OType	= GPIO_OType_PP;
 	GPIO_Pulses.GPIO_PuPd		= GPIO_PuPd_NOPULL;
 	GPIO_Pulses.GPIO_Speed	= GPIO_Speed_100MHz;
-	
+
 	GPIO_Init(GPIOA, &GPIO_Pulses);
-	
+
 	PULSE_LED_II_ALL_OFF;
 	PULSE_LED_II_1_OFF;
 	PULSE_LED_II_2_OFF;
@@ -1482,10 +1493,10 @@ Init GPIOs for display leds
 void DisplayLedsIOInit(void)
 {
 	GPIO_InitTypeDef GPIO_InitStructure;
-	
+
 	//Ã�ËœÃ�Â½Ã�Â¸Ã‘â€ Ã�Â¸Ã�Â°Ã�Â»Ã�Â¸Ã�Â·Ã�Â°Ã‘ï¿½ Ã�Â¿Ã�ÂµÃ‘â‚¬Ã�Â¸Ã‘â€žÃ�ÂµÃ‘â‚¬Ã�Â¸Ã�Â¸ Ã�Â´Ã�Â»Ã‘ï¿½ Ã‘Æ’Ã�Â¿Ã‘â‚¬Ã�Â°Ã�Â²Ã�Â»Ã�ÂµÃ�Â½Ã�Â¸Ã‘ï¿½ Ã‘ï¿½Ã�Â²Ã�ÂµÃ‘â€šÃ�Â¾Ã�Â´Ã�Â¸Ã�Â¾Ã�Â´Ã�Â°Ã�Â¼Ã�Â¸ DISPLAY
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
-	
+
 	GPIO_InitStructure.GPIO_Pin 	= DISPLAY_LED_I|DISPLAY_LED_II;
 	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
 	GPIO_InitStructure.GPIO_Mode 	= GPIO_Mode_OUT;
@@ -1500,32 +1511,32 @@ void InternalDACInit(void)
 {
 	DAC_InitTypeDef mDacInit;
 	GPIO_InitTypeDef mGPIO_InitStructure;
-	
+
 	DAC_StructInit(&mDacInit);
 	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
 
 	//GPIOs init
-	
+
 	mGPIO_InitStructure.GPIO_Pin 	= GPIO_Pin_4|GPIO_Pin_5;
 	mGPIO_InitStructure.GPIO_Mode = GPIO_Mode_AN;
 	GPIO_Init(GPIOA, &mGPIO_InitStructure);
-		
+
 	/* DAC Periph clock enable */
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	
+
 	//DAC init
 	mDacInit.DAC_Trigger 				= DAC_Trigger_None;
 	mDacInit.DAC_OutputBuffer 	= DAC_OutputBuffer_Disable;
 	mDacInit.DAC_WaveGeneration = DAC_WaveGeneration_None;
 
 	DAC_DeInit();
-	
+
 	DAC_Init(DAC_Channel_1, &mDacInit);
 	DAC_Init(DAC_Channel_2, &mDacInit);
-	
+
 	DAC_Cmd(DAC_Channel_1, ENABLE);
 	DAC_Cmd(DAC_Channel_2, ENABLE);
-	
+
 	DAC_SetChannel1Data(DAC_Align_12b_R, 0);
 	DAC_SetChannel2Data(DAC_Align_12b_R, 0);
 };
@@ -1537,10 +1548,10 @@ unsigned char keyb_proc(uButtons * key)
 {
 	unsigned char StepNum = 0, Section = 0, max_step;
 	uStep tmpStep;
-	
+
 	if(Is_Expander_Present()) max_step = 31;
 	else max_step = 15;
-			 
+
 	/* Determine step num for different DisplayModes */
 	if (gDisplayMode == DISPLAY_MODE_VIEW_1) {
 		StepNum = gSequenceStepNumber_1;
@@ -1558,7 +1569,7 @@ unsigned char keyb_proc(uButtons * key)
 		StepNum = gEditModeStepNum;
 		Section = 1;
 	};
-	
+
 	if (gDisplayMode == DISPLAY_MODE_SAVE_1) {
 		StepNum = gEditModeStepNum;
 		Section = 0;
@@ -1575,12 +1586,12 @@ unsigned char keyb_proc(uButtons * key)
 		StepNum = gEditModeStepNum;
 		Section = 1;
 	};
-	
-	tmpStep = Steps[Section][StepNum];	
-				
-	
+
+	tmpStep = Steps[Section][StepNum];
+
+
 		/* Middle section */
-		
+
 		if ( !key->b.Voltage0 ) {
 			tmpStep.b.Voltage0 = 1;
 			tmpStep.b.Voltage2 = 0;
@@ -1589,7 +1600,7 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 0;
 			tmpStep.b.FullRange = 0;
 		};
-		
+
 		if ( !key->b.Voltage2 ) {
 			tmpStep.b.Voltage0 = 0;
 			tmpStep.b.Voltage2 = 1;
@@ -1598,7 +1609,7 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 0;
 			tmpStep.b.FullRange = 0;
 		};
-		
+
 		if ( !key->b.Voltage4 ) {
 			tmpStep.b.Voltage0 = 0;
 			tmpStep.b.Voltage2 = 0;
@@ -1607,7 +1618,7 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 0;
 			tmpStep.b.FullRange = 0;
 		};
-		
+
 		if ( !key->b.Voltage6 ) {
 			tmpStep.b.Voltage0 = 0;
 			tmpStep.b.Voltage2 = 0;
@@ -1616,7 +1627,7 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 0;
 			tmpStep.b.FullRange = 0;
 		};
-		
+
 		if ( !key->b.Voltage8 ) {
 			tmpStep.b.Voltage0 = 0;
 			tmpStep.b.Voltage2 = 0;
@@ -1625,7 +1636,7 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 1;
 			tmpStep.b.FullRange = 0;
 		};
-		
+
 		if ( !key->b.FullRangeOn ) {
 			tmpStep.b.Voltage0 = 0;
 			tmpStep.b.Voltage2 = 0;
@@ -1634,47 +1645,47 @@ unsigned char keyb_proc(uButtons * key)
 			tmpStep.b.Voltage8 = 0;
 			tmpStep.b.FullRange = 1;
 		};
-		
+
 		if ( !key->b.Pulse1On ) {
 			tmpStep.b.OutputPulse1 = 1;
 		};
-		
+
 		if ( !key->b.Pulse1Off ) {
 			tmpStep.b.OutputPulse1 = 0;
 		};
-		
+
 		if ( !key->b.Pulse2On ) {
 			tmpStep.b.OutputPulse2 = 1;
 		};
-		
+
 		if ( !key->b.Pulse2Off ) {
 			tmpStep.b.OutputPulse2 = 0;
 		};
-		
+
 		if ( !key->b.OutputQuantize ) {
 			tmpStep.b.Quantize = 1;
 		};
-		
+
 		if ( !key->b.OutputContinuous ) {
 			tmpStep.b.Quantize = 0;
 		};
-		
+
 		if ( !key->b.IntegrationSloped ) {
 			tmpStep.b.Sloped = 1;
 		};
-		
+
 		if ( !key->b.IntegrationStepped ) {
 			tmpStep.b.Sloped = 0;
 		};
-		
+
 		if ( !key->b.SourceExternal ) {
 			tmpStep.b.VoltageSource = 1;
 		};
-		
+
 		if ( !key->b.SourceInternal ) {
 			tmpStep.b.VoltageSource = 0;
 		};
-		
+
 		if ( !key->b.StopOn ) {
 			tmpStep.b.OpModeSTOP = 1;
 			tmpStep.b.OpModeENABLE = 0;
@@ -1692,12 +1703,12 @@ unsigned char keyb_proc(uButtons * key)
 				gSequencerMode_2 = SEQUENCER_MODE_STOP;
 				};
 		};
-		
+
 		if ( !key->b.StopOff ) {
 			tmpStep.b.OpModeSTOP = 0;
 			/* Determine step num for different DisplayModes */
 		};
-		
+
 		if ( !key->b.SustainOn ) {
 			tmpStep.b.OpModeSUSTAIN = 1;
 			tmpStep.b.OpModeSTOP = 0;
@@ -1709,7 +1720,7 @@ unsigned char keyb_proc(uButtons * key)
 				gSequencerMode_2 = gPrevSequencerMode_2;
 			};
 		};
-		
+
 		if ( !key->b.SustainOff ) {
 			tmpStep.b.OpModeSUSTAIN = 0;
 			if ((gDisplayMode == DISPLAY_MODE_VIEW_1 || gDisplayMode == DISPLAY_MODE_EDIT_1) && gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z) {
@@ -1719,7 +1730,7 @@ unsigned char keyb_proc(uButtons * key)
 				gSequencerMode_2 = gPrevSequencerMode_2;
 			};
 		};
-		
+
 		if ( !key->b.EnableOn ) {
 			tmpStep.b.OpModeENABLE = 1;
 			tmpStep.b.OpModeSTOP = 0;
@@ -1731,7 +1742,7 @@ unsigned char keyb_proc(uButtons * key)
 				gSequencerMode_2 = gPrevSequencerMode_2;
 			};
 		};
-		
+
 		if ( !key->b.EnableOff ) {
 			tmpStep.b.OpModeENABLE = 0;
 				if ((gDisplayMode == DISPLAY_MODE_VIEW_1 || gDisplayMode == DISPLAY_MODE_EDIT_1) && gSequencerMode_1 == SEQUENCER_MODE_WAIT_HI_Z) {
@@ -1741,61 +1752,61 @@ unsigned char keyb_proc(uButtons * key)
 				gSequencerMode_2 = gPrevSequencerMode_2;
 			};
 		};
-		
+
 		if ( !key->b.FirstOn ) {
 			tmpStep.b.CycleFirst = 1;
 			tmpStep.b.CycleLast = 0;
 		};
-		
+
 		if ( !key->b.FirstOff ) {
 			tmpStep.b.CycleFirst = 0;
 		};
-		
-		if ( !key->b.LastOn ) {		
+
+		if ( !key->b.LastOn ) {
 			tmpStep.b.CycleLast = 1;
 			tmpStep.b.CycleFirst = 0;
 		};
-		
+
 		if ( !key->b.LastOff ) {
 			tmpStep.b.CycleLast = 0;
 		};
-		
+
 		if ( !key->b.TimeSourceExternal ) {
 			tmpStep.b.TimeSource = 1;
 		};
-		
+
 		if ( !key->b.TimeSourceInternal ) {
 			tmpStep.b.TimeSource = 0;
 		};
-		
+
 		if (!key->b.TimeRange1) {
 			tmpStep.b.TimeRange_p03 = 1;
 			tmpStep.b.TimeRange_p3 =  0;
 			tmpStep.b.TimeRange_3 =   0;
-			tmpStep.b.TimeRange_30 =  0;                        
+			tmpStep.b.TimeRange_30 =  0;
 		};
 
 		if (!key->b.TimeRange2) {
 			tmpStep.b.TimeRange_p03 = 0;
 			tmpStep.b.TimeRange_p3 =  1;
 			tmpStep.b.TimeRange_3 =   0;
-			tmpStep.b.TimeRange_30 =  0; 
+			tmpStep.b.TimeRange_30 =  0;
 		};
 
 		if (!key->b.TimeRange3) {
 			tmpStep.b.TimeRange_p03 = 0;
 			tmpStep.b.TimeRange_p3 =  0;
 			tmpStep.b.TimeRange_3 =   1;
-			tmpStep.b.TimeRange_30 =  0; 
+			tmpStep.b.TimeRange_30 =  0;
 		};
 
 		if (!key->b.TimeRange4) {
 			tmpStep.b.TimeRange_p03 = 0;
 			tmpStep.b.TimeRange_p3 =  0;
 			tmpStep.b.TimeRange_3 =   0;
-			tmpStep.b.TimeRange_30 =  1; 
+			tmpStep.b.TimeRange_30 =  1;
 		};
-		
+
 		if (!key->b.ClearUp)  {
 			//Init timer to detect long press (clear comman)
 			InitClear_Timer();
@@ -1804,7 +1815,7 @@ unsigned char keyb_proc(uButtons * key)
 				LoadSequence(gEditModeStepNum);
 				gKeysNotValid = 1;
 				gDisplayMode = DISPLAY_MODE_VIEW_1;
-				
+
 				gPrevSequencerMode_1 = gSequencerMode_1;
 				gSequenceStepNumber_1 = 0;
 				gSequencerMode_1 = SEQUENCER_MODE_STOP;
@@ -1819,7 +1830,7 @@ unsigned char keyb_proc(uButtons * key)
 				gSequenceStepNumber_2 = 0;
 				gSequencerMode_2 = SEQUENCER_MODE_STOP;
 			}
-			
+
 			else if (gDisplayMode == DISPLAY_MODE_VIEW_1) {
 				//if in view mode switch to load mode
 				gDisplayMode = DISPLAY_MODE_LOAD_1;
@@ -1833,9 +1844,9 @@ unsigned char keyb_proc(uButtons * key)
 				gEditModeStepNum = 0;
 				DisplayUpdateFlags.b.StepsDisplay = 1;
 				DisplayUpdateFlags.b.MainDisplay = 1;
-			};			
+			};
 		};
-		
+
 		if (!key->b.ClearDown)  {
 			InitClear_Timer();
 			if (gDisplayMode == DISPLAY_MODE_SAVE_1) {
@@ -1848,7 +1859,7 @@ unsigned char keyb_proc(uButtons * key)
 				SaveSequence(gEditModeStepNum);
 				gDisplayMode = DISPLAY_MODE_VIEW_2;
 			}
-			
+
 			else if (gDisplayMode == DISPLAY_MODE_VIEW_1) {
 				//if in view mode - switch to save mode
 				gDisplayMode = DISPLAY_MODE_SAVE_1;
@@ -1856,7 +1867,7 @@ unsigned char keyb_proc(uButtons * key)
 				DisplayUpdateFlags.b.StepsDisplay = 1;
 				DisplayUpdateFlags.b.MainDisplay = 1;
 			}
-			
+
 			else if (gDisplayMode == DISPLAY_MODE_VIEW_2) {
 				//if in view mode - switch to save mode
 				gDisplayMode = DISPLAY_MODE_SAVE_2;
@@ -1864,11 +1875,11 @@ unsigned char keyb_proc(uButtons * key)
 				DisplayUpdateFlags.b.StepsDisplay = 1;
 				DisplayUpdateFlags.b.MainDisplay = 1;
 
-			};			
+			};
 		};
-		
 
-		
+
+
 		//switch to edit mode
 		if ( !key->b.StepLeft ) {
 			if (gDisplayMode == DISPLAY_MODE_VIEW_1) {
@@ -1911,7 +1922,7 @@ unsigned char keyb_proc(uButtons * key)
 					DisplayUpdateFlags.b.StepsDisplay = 1;
 				};
 			};
-			
+
 			//if in save or load mode left buttons select memory cell for save/recall
 			if ( (gDisplayMode == DISPLAY_MODE_SAVE_1) || (gDisplayMode == DISPLAY_MODE_SAVE_2) ||
 				 (gDisplayMode == DISPLAY_MODE_LOAD_1) || (gDisplayMode == DISPLAY_MODE_LOAD_2) ) {
@@ -1928,16 +1939,16 @@ unsigned char keyb_proc(uButtons * key)
 					counterL++;
 					DisplayUpdateFlags.b.StepsDisplay = 1;
 				} else {
-					if(counterL == 0) 
+					if(counterL == 0)
 					{
 							if(!Is_Expander_Present())
-							{	
+							{
 							gEditModeStepNum = 15;
-							if(bank == 1) 
+							if(bank == 1)
 							{
 								bank = 2;
 							}
-							else 
+							else
 							{
 								bank = 1;
 							}
@@ -1950,13 +1961,13 @@ unsigned char keyb_proc(uButtons * key)
 						{
 							counterL = 500;
 							if(!Is_Expander_Present())
-							{	
+							{
 								gEditModeStepNum = 15;
-								if(bank == 1) 
+								if(bank == 1)
 								{
 									bank = 2;
 								}
-								else 
+								else
 								{
 									bank = 1;
 								}
@@ -1970,11 +1981,11 @@ unsigned char keyb_proc(uButtons * key)
 				};
 			};
 		}
-		else 
+		else
 		{
 			counterL = 0;
 		};
-		
+
 		if ( !key->b.StepRight ) {
 			if (gDisplayMode == DISPLAY_MODE_VIEW_1) {
 				gDisplayMode = DISPLAY_MODE_EDIT_1;
@@ -2013,8 +2024,8 @@ unsigned char keyb_proc(uButtons * key)
 					DisplayUpdateFlags.b.MainDisplay = 1;
 					DisplayUpdateFlags.b.StepsDisplay = 1;
 				};
-			};			
-						
+			};
+
 			//if in save or load mode right buttons select memory cell for save/recall
 			if ( (gDisplayMode == DISPLAY_MODE_SAVE_1) || (gDisplayMode == DISPLAY_MODE_SAVE_2) ||
 				(gDisplayMode == DISPLAY_MODE_LOAD_1) || (gDisplayMode == DISPLAY_MODE_LOAD_2)) {
@@ -2031,23 +2042,23 @@ unsigned char keyb_proc(uButtons * key)
 					counterR++;
 					DisplayUpdateFlags.b.StepsDisplay = 1;
 				} else {
-					
-					if(counterR == 0) 
+
+					if(counterR == 0)
 					{
 							if(!Is_Expander_Present())
-							{	
+							{
 								gEditModeStepNum = 0;
-								if(bank == 1) 
+								if(bank == 1)
 								{
 									bank = 2;
-									
+
 								}
-								else 
+								else
 								{
 									bank = 1;
 								}
 							}
-							else 
+							else
 							{
 								gEditModeStepNum = 0;
 							}
@@ -2058,19 +2069,19 @@ unsigned char keyb_proc(uButtons * key)
 						{
 							counterR = 500;
 							if(!Is_Expander_Present())
-							{	
+							{
 								gEditModeStepNum = 0;
-								if(bank == 1) 
+								if(bank == 1)
 								{
 									bank = 2;
-									
+
 								}
-								else 
+								else
 								{
 									bank = 1;
 								}
 							}
-							else 
+							else
 							{
 								gEditModeStepNum = 0;
 							}
@@ -2082,32 +2093,32 @@ unsigned char keyb_proc(uButtons * key)
 				};
 			};
 		}
-		else 
+		else
 		{
 			counterR = 0;
 		};
 	key_locked = 1;
-	
-		
+
+
 		//Sections 1/2
 	if (gKeysNotValid == 0) {
-		
+
 	if (!key->b.StageAddress1Display) {
-			if (gDisplayMode != DISPLAY_MODE_VIEW_1) {			
+			if (gDisplayMode != DISPLAY_MODE_VIEW_1) {
 				gDisplayMode = DISPLAY_MODE_VIEW_1;
-			};		
+			};
 		};
-		
+
 
 		if (!key->b.StageAddress2Display) {
-			if (gDisplayMode != DISPLAY_MODE_VIEW_2) {			
+			if (gDisplayMode != DISPLAY_MODE_VIEW_2) {
 				gDisplayMode = DISPLAY_MODE_VIEW_2;
 				key_locked = 0;
 			};
 		};
 	};
-		
-	
+
+
 
 		if ( (!key->b.StageAddress1Reset)  ) {
 				if(gSequencerMode_1 != SEQUENCER_MODE_WAIT)
@@ -2120,45 +2131,45 @@ unsigned char keyb_proc(uButtons * key)
 				}
 			};
 		};
-					
+
 
 		if ( (!key->b.StageAddress2Reset)  ) {
 				if(gSequencerMode_2 != SEQUENCER_MODE_WAIT)
-				{						
+				{
 					gSequenceStepNumber_2 = 0;
 					DisplayUpdateFlags.b.MainDisplay = 1;
 					DisplayUpdateFlags.b.StepsDisplay = 1;
-					
+
 					if (gSequencerMode_2 == SEQUENCER_MODE_WAIT_HI_Z || gSequencerMode_2 == SEQUENCER_MODE_STAY_HI_Z) {
 					gSequencerMode_2 = gPrevSequencerMode_2;
 				}
 		};
 		}
-				
+
 		if( key->b.Empty5 && strobe_banana_flag1 == 0)
 		{
 			strobe_banana_flag1 = 1;
 				gSequenceStepNumber_1 = (unsigned int) (pots_step[0]-1);
-			
+
 			if ( gDisplayMode == DISPLAY_MODE_VIEW_1 ) {
 				DisplayUpdateFlags.b.MainDisplay = 1;
 				DisplayUpdateFlags.b.StepsDisplay = 1;
 			};
-			
+
 				PULSE_LED_I_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_I_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_I_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM14, ENABLE);
 				TIM_SetCounter(TIM14, 0x00);
 		}
-		
-		if(!key->b.Empty5) 
+
+		if(!key->b.Empty5)
 		{
 			strobe_banana_flag1 = 0;
 		}
@@ -2168,21 +2179,21 @@ unsigned char keyb_proc(uButtons * key)
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-			
+
 				PULSE_LED_I_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_I_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_I_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM14, ENABLE);
 				TIM_SetCounter(TIM14, 0x00);
 		};
-		
-						
+
+
 		if( key->b.Empty2 && strobe_banana_flag2 == 0)
 		{
 			strobe_banana_flag2 = 1;
@@ -2191,21 +2202,21 @@ unsigned char keyb_proc(uButtons * key)
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-			
+
 				PULSE_LED_II_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_II_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_II_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM8, ENABLE);
 			TIM_SetCounter(TIM8, 0x00);
 		}
-		
-		if(!key->b.Empty2) 
+
+		if(!key->b.Empty2)
 		{
 			strobe_banana_flag2 = 0;
 		}
@@ -2217,26 +2228,26 @@ unsigned char keyb_proc(uButtons * key)
 		DisplayUpdateFlags.b.MainDisplay = 1;
 		DisplayUpdateFlags.b.StepsDisplay = 1;
 	};
-			
+
 				PULSE_LED_II_ALL_ON;
-				
+
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse1) {
 					PULSE_LED_II_1_ON;
 				};
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse2) {
 					PULSE_LED_II_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM8, ENABLE);
 			TIM_SetCounter(TIM8, 0x00);
-		};		
-	
-				
+		};
+
+
 	/* Stage address ADVANCE 1 KEY*/
 	if (!key->b.StageAddress1ContiniousSelect) {
 		if (gSequencerMode_1 != SEQUENCER_MODE_WAIT) {
 			gPrevSequencerMode_1 = gSequencerMode_1;
-			gSequencerMode_1 = SEQUENCER_MODE_WAIT;		
+			gSequencerMode_1 = SEQUENCER_MODE_WAIT;
 			DisplayUpdateFlags.b.MainDisplay = 1;
 			key_locked = 0;
 		};
@@ -2248,8 +2259,8 @@ unsigned char keyb_proc(uButtons * key)
 			key_locked = 0;
 		};
 	};
-	
-	if (!key->b.StageAddress2ContiniousSelect) {	
+
+	if (!key->b.StageAddress2ContiniousSelect) {
 		if (gSequencerMode_2 != SEQUENCER_MODE_WAIT) {
 			gPrevSequencerMode_2 = gSequencerMode_2;
 			gSequencerMode_2 = SEQUENCER_MODE_WAIT;
@@ -2257,22 +2268,22 @@ unsigned char keyb_proc(uButtons * key)
 			key_locked = 0;
 		};
 	} else {
-		if (gSequencerMode_2 == SEQUENCER_MODE_WAIT) {			
+		if (gSequencerMode_2 == SEQUENCER_MODE_WAIT) {
 			gSequencerMode_2 = gPrevSequencerMode_2;
 			DisplayUpdateFlags.b.MainDisplay = 1;
-			DisplayUpdateFlags.b.StepsDisplay = 1;			
+			DisplayUpdateFlags.b.StepsDisplay = 1;
 			key_locked = 0;
 		};
 	};
-	
+
 	if (!key->b.StageAddress1Advance) {
-		
+
 		advanced_counter_1++;
 		if(advanced_counter_1 == 10)
 		{
 		if(gSequencerMode_1 != SEQUENCER_MODE_WAIT)
 		{
-		if(gSequencerMode_1 == SEQUENCER_MODE_ADVANCE) 
+		if(gSequencerMode_1 == SEQUENCER_MODE_ADVANCE)
 		{
 			PreviousStep = GetStepVoltage(0, gSequenceStepNumber_1);
 			gSequenceStepNumber_1 = GetNextStep(0, gSequenceStepNumber_1);
@@ -2280,66 +2291,66 @@ unsigned char keyb_proc(uButtons * key)
 		}
 		else{
 			if(gSequencerMode_1 != SEQUENCER_MODE_STAY_HI_Z && gSequencerMode_1 != SEQUENCER_MODE_WAIT_HI_Z )(gPrevSequencerMode_1 = gSequencerMode_1);
-			
+
 			gSequenceStepNumber_1 = GetNextStep(0, gSequenceStepNumber_1);
 		}
 		gSequencerMode_1 = SEQUENCER_MODE_ADVANCE;
 						PULSE_LED_I_ALL_ON;
-				
+
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse1) {
 					PULSE_LED_I_1_ON;
 				};
 				if (Steps[0][gSequenceStepNumber_1].b.OutputPulse2) {
 					PULSE_LED_I_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM14, ENABLE);
 				TIM_SetCounter(TIM14, 0x00);
 	}	}
 	} else advanced_counter_1 = 0;
-	
+
 		if (!key->b.StageAddress2Advance) {
-			
+
 		advanced_counter_2++;
 		if(advanced_counter_2 == 10)
 		{
 		if(gSequencerMode_2 != SEQUENCER_MODE_WAIT)
 				{
-		if(gSequencerMode_2 == SEQUENCER_MODE_ADVANCE) 
+		if(gSequencerMode_2 == SEQUENCER_MODE_ADVANCE)
 		{
 			PreviousStep_2 = GetStepVoltage(1, gSequenceStepNumber_2);
 			gSequenceStepNumber_2 = GetNextStep(1, gSequenceStepNumber_2);
 			gStepWidth_2 = 0;
 		}
-		else 
+		else
 		{
 			if(gSequencerMode_2 != SEQUENCER_MODE_STAY_HI_Z && gSequencerMode_2 != SEQUENCER_MODE_WAIT_HI_Z )(gPrevSequencerMode_2 = gSequencerMode_2);
 			gSequenceStepNumber_2 = GetNextStep(1, gSequenceStepNumber_2);
 		}
 		gSequencerMode_2 = SEQUENCER_MODE_ADVANCE;
 				PULSE_LED_II_ALL_ON;
-				
+
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse1) {
 					PULSE_LED_II_1_ON;
 				};
 				if (Steps[1][gSequenceStepNumber_2].b.OutputPulse2) {
 					PULSE_LED_II_2_ON;
-				};	
-				
+				};
+
 				TIM_Cmd(TIM8, ENABLE);
 			TIM_SetCounter(TIM8, 0x00);
-	
+
 			}
 	}
 	}else advanced_counter_2 = 0;
-				
+
 	if (gKeysNotValid == 0) {
-		Steps[Section][StepNum] = tmpStep;				
-		DisplayUpdateFlags.b.MainDisplay = 1;	
+		Steps[Section][StepNum] = tmpStep;
+		DisplayUpdateFlags.b.MainDisplay = 1;
 	} else {
 		gKeysNotValid = 0;
 	};
-				
+
 	return 1;
 }
 
@@ -2352,7 +2363,7 @@ void UpdateModeSection(void)
 	unsigned char StepNum = 0, Section = 0;
 	uLeds mLeds;
 	uStep *mStep;
-	
+
 	mLeds.value[0] = 0xFF;
 	mLeds.value[1] = 0xFF;
 	mLeds.value[2] = 0xFF;
@@ -2367,11 +2378,11 @@ void UpdateModeSection(void)
 			(gSequencerMode_1 == SEQUENCER_MODE_STAY_HI_Z)  ) {
 		mLeds.b.Seq1Wait = 0;
 	};
-			
+
 	if (gSequencerMode_1 == SEQUENCER_MODE_STOP) {
 		mLeds.b.Seq1Stop = 0;
 	};
-	
+
 	if ((gSequencerMode_2 == SEQUENCER_MODE_RUN) ||
 			(gSequencerMode_2 == SEQUENCER_MODE_ADVANCE) ) {
 		mLeds.b.Seq2Run = 0;
@@ -2384,8 +2395,8 @@ void UpdateModeSection(void)
 	if (gSequencerMode_2 == SEQUENCER_MODE_STOP) {
 		mLeds.b.Seq2Stop = 0;
 	};
-	
-	
+
+
 	/* Determine step num for different DisplayModes*/
 	if ( gDisplayMode == DISPLAY_MODE_VIEW_1 ) {
 		StepNum = gSequenceStepNumber_1;
@@ -2403,9 +2414,9 @@ void UpdateModeSection(void)
 		StepNum = gEditModeStepNum;
 		Section = 1;
 	};
-	
+
 	mStep = (uStep*) &Steps[Section][StepNum];
-	
+
 	mLeds.b.VoltageFull  	= ~mStep->b.FullRange;
   mLeds.b.Voltage0     	= ~mStep->b.Voltage0;
   mLeds.b.Voltage2     	= ~mStep->b.Voltage2;
@@ -2427,14 +2438,14 @@ void UpdateModeSection(void)
   mLeds.b.OPStop       	= ~mStep->b.OpModeSTOP;
   mLeds.b.OPSustain    	= ~mStep->b.OpModeSUSTAIN;
   mLeds.b.OPEnable     	= ~mStep->b.OpModeENABLE;
-	
+
 	if ( (gDisplayMode == DISPLAY_MODE_SAVE_1) || (gDisplayMode == DISPLAY_MODE_SAVE_2) ||
 		(gDisplayMode == DISPLAY_MODE_LOAD_1) || (gDisplayMode == DISPLAY_MODE_LOAD_2) ) {
 		mLeds.value[0] = 0xFF;
 		mLeds.value[1] = 0xFF;
 		mLeds.value[2] = 0xFF;
 		mLeds.value[3] = 0xFF;
-					
+
 		if((gDisplayMode == DISPLAY_MODE_SAVE_1) || (gDisplayMode == DISPLAY_MODE_SAVE_2))
 		{
 			mLeds.b.Seq2Wait = 1;
@@ -2462,26 +2473,26 @@ void UpdateModeSection(void)
 				 mLeds.b.Seq2Wait = 1;
 			}
 			else load_counter = 0;
-			
-			
+
+
 		}
-			
+
 		if(!Is_Expander_Present())
-		{	
+		{
 			if(bank == 1) mLeds.value[0] &= ~(1 << 6);
 			else mLeds.value[0] &= ~(1 << 7);
 		}
 	};
-	
+
 	//Send data to leds
 	LEDS_modes_SendStruct(&mLeds);
-	
+
 	if ( (gDisplayMode == DISPLAY_MODE_VIEW_1) ||
 			(gDisplayMode == DISPLAY_MODE_EDIT_1) ) {
 		DISPLAY_LED_I_ON;
 		DISPLAY_LED_II_OFF;
 	};
-			
+
 	if ( (gDisplayMode == DISPLAY_MODE_VIEW_2) ||
 			(gDisplayMode == DISPLAY_MODE_EDIT_2) ) {
 		DISPLAY_LED_II_ON;
@@ -2504,7 +2515,7 @@ void UpdateStepSection(void)
 		( gDisplayMode == DISPLAY_MODE_EDIT_2 ) ||
 		( gDisplayMode == DISPLAY_MODE_SAVE_1 ) ||
 		( gDisplayMode == DISPLAY_MODE_SAVE_2 ) ||
-		(gDisplayMode == DISPLAY_MODE_LOAD_1) || 
+		(gDisplayMode == DISPLAY_MODE_LOAD_1) ||
 		(gDisplayMode == DISPLAY_MODE_LOAD_2)
 		) {
 		LED_STEP_LightStep(gEditModeStepNum);
@@ -2516,16 +2527,16 @@ void Calibration(void)
 {
 	unsigned long i;
 	uButtons myButtons;
-	uLeds mLeds;	
+	uLeds mLeds;
 	volatile unsigned long long int key_state;
-	
+
 	mLeds.value[0]  	= 0xFF;
 	mLeds.value[1]  	= 0xFF;
 	mLeds.value[2]  	= 0xFF;
 	mLeds.value[3]  	= 0xFF;
 	DISPLAY_LED_II_OFF;
 	DISPLAY_LED_I_OFF;
-	
+
 	while(myButtons.b.StageAddress2Advance)
 	{
 		//Run/Wait/Stop leds blinking
@@ -2558,7 +2569,7 @@ void Calibration(void)
 			mLeds.b.Seq2Stop = 1;
 		}
 		else i = 0;
-		
+
 		LEDS_modes_SendStruct(&mLeds);
 
 		myButtons.value = GetButton();
@@ -2614,7 +2625,7 @@ void Calibration(void)
 int main(void)
 {
 	uButtons myButtons;
-	uLeds mLeds;	
+	uLeds mLeds;
 	unsigned char _cnt;
 	volatile unsigned long long int key_state, prev_key_state;
 
@@ -2622,47 +2633,47 @@ int main(void)
 	unsigned char KeyThreshHoldCnt = 0, max_step;
 	uint16_t  next_step_tres = 0, prev_step_tres = 0, temp;
 	int i, j;
-	long acc;	
-	
+	long acc;
+
 	/* Reset update states */
 	DisplayUpdateFlags.value = 0x00;
 	DisplayUpdateFlags.b.MainDisplay 	= 1;
 	DisplayUpdateFlags.b.StepsDisplay = 1;
-	
+
 	/* Init steps structures */
 	Steps[0][0].b.TimeRange_p3 = 1;
 	Steps[0][0].b.FullRange = 1;
 	Steps[1][0] = Steps[0][0];
-	
-	for(_cnt=1;_cnt<=15;_cnt++) 
+
+	for(_cnt=1;_cnt<=15;_cnt++)
 	{
-		Steps[0][_cnt] = Steps[0][0];		
+		Steps[0][_cnt] = Steps[0][0];
 		Steps[1][_cnt] = Steps[0][0];
-		Steps[0][_cnt+16] = Steps[0][0];		
+		Steps[0][_cnt+16] = Steps[0][0];
 		Steps[1][_cnt+16] = Steps[0][0];
 	};
-	
+
 	//Debug stuff
 	RCC_GetClocksFreq(&RCC_Clocks);
 
 	PulsesInit();
 	DisplayLedsIOInit();
-		
-	DipConfig_init();	
-	gDipConfig = GetDipConfig(); 
-		
-	/* Out dip switch state to panel */ 
+
+	DipConfig_init();
+	gDipConfig = GetDipConfig();
+
+	/* Out dip switch state to panel */
 	LED_STEP_init();
 	LED_STEP_SendWord(0xFFFF);
 	delay_ms(1000);
 	LED_STEP_SendWord(0xFFF0|(*((uint8_t*) (&gDipConfig))));
 	delay_ms(1000);
-	
+
 	//Init external memory
 	CAT25512_init();
-		
+
 	/* LEDs for mode display */
-	LEDS_modes_init();	
+	LEDS_modes_init();
 	mLeds.value[0] = 0xFF;
 	mLeds.value[1] = 0xFF;
 	mLeds.value[2] = 0xFF;
@@ -2670,39 +2681,39 @@ int main(void)
 	mLeds.b.Seq1Stop = 0;
 	mLeds.b.Seq2Stop = 0;
 	LEDS_modes_SendStruct(&mLeds);
-	
+
 	/* Switches input config */
 	init_HC165();
 	key_state = GetButton();
 	prev_key_state = 0x7fbf67f7fffdff;//key_state;
-	
+
 	/* External DAC config */
 	MAX5135init();
-	
+
 	/* ADC configuration */
 	ADC_POTS_selector_init();
 	ADC_POTS_selector_Ch(0);
 	mADC_init();
-	
+
 	mTimersInit();
 	mInterruptInit();
-	
+
 	InternalDACInit();
 	Init_Expander_GPIO();
-	
+
 	gSequencerMode_1 = SEQUENCER_MODE_STOP;
 	gSequencerMode_2 = SEQUENCER_MODE_STOP;
-	
-//Scan initial state	
+
+//Scan initial state
 	key_state == GetButton();
 	myButtons.value = key_state;
-	
-	if(!myButtons.b.StageAddress1Advance) 
+
+	if(!myButtons.b.StageAddress1Advance)
 	{
 		//if advance switch is pressed start calibration
 		Calibration();
 	}
-	else 
+	else
 	{
 		//if not restore calibration constants from memory
 		CAT25512_read_block(100*sizeof(Steps), (unsigned char *) CalConstants, sizeof(CalConstants));
@@ -2712,10 +2723,10 @@ int main(void)
 		}
 	}
 
-	while(1) {		
+	while(1) {
 		gDipConfig = GetDipConfig();
 		//Set offset and divider which depend on dip switch state
-		if(gDipConfig.b.V_OUT_1V == 1) 
+		if(gDipConfig.b.V_OUT_1V == 1)
 		{
 			offset = (4095.0/10.0);
 			divider = 10.0;
@@ -2737,48 +2748,48 @@ int main(void)
 		/* keys proceed */
 		if (KeyThreshHoldCnt == 0) {
 			key_state = GetButton();
-		};		
-		
+		};
+
 		if (KeyThreshHoldCnt == 2) {
-			if (key_state == GetButton()) {	
-				myButtons.value = key_state;			
+			if (key_state == GetButton()) {
+				myButtons.value = key_state;
 							if ( 	(gDisplayMode != DISPLAY_MODE_SAVE_1) && (gDisplayMode != DISPLAY_MODE_SAVE_2) &&
-						(gDisplayMode != DISPLAY_MODE_LOAD_1) && (gDisplayMode != DISPLAY_MODE_LOAD_2) ) 
+						(gDisplayMode != DISPLAY_MODE_LOAD_1) && (gDisplayMode != DISPLAY_MODE_LOAD_2) )
 			{
 				if (key_state != prev_key_state || myButtons.b.StepRight == 0 || myButtons.b.StepLeft == 0) {
-						
+
 						keyb_proc(&myButtons);
 						prev_key_state = key_state;
 				};
 			}
-			else 
+			else
 			{
 							if (key_state != prev_key_state || myButtons.b.StepRight == 0 || myButtons.b.StepLeft == 0) {
-						
+
 						keyb_proc(&myButtons);
 						prev_key_state = key_state;
-				};	
+				};
 			}
 			};
 		};
-		
+
 		KeyThreshHoldCnt++;
 		if (KeyThreshHoldCnt > 2) {
 			KeyThreshHoldCnt = 0;
 		};
 		/* ENDOF: keys proceed */
-		
+
 		//Update panel state
 		if (DisplayUpdateFlags.b.MainDisplay) {
 			UpdateModeSection();
 			DisplayUpdateFlags.b.MainDisplay = 0;
 			if ( 	(gDisplayMode == DISPLAY_MODE_SAVE_1) || (gDisplayMode == DISPLAY_MODE_SAVE_2) ||
-						(gDisplayMode == DISPLAY_MODE_LOAD_1) || (gDisplayMode == DISPLAY_MODE_LOAD_2) ) 
+						(gDisplayMode == DISPLAY_MODE_LOAD_1) || (gDisplayMode == DISPLAY_MODE_LOAD_2) )
 			{
 				DisplayUpdateFlags.b.MainDisplay = 1;
 			}
 		};
-		if (DisplayUpdateFlags.b.StepsDisplay) {			
+		if (DisplayUpdateFlags.b.StepsDisplay) {
 			UpdateStepSection();
 			DisplayUpdateFlags.b.StepsDisplay = 0;
 		};
@@ -2787,42 +2798,42 @@ int main(void)
 	{
 		//Calculation of step number if external control is on
 			if(Is_Expander_Present()) max_step = 31;
-			else 
+			else
 			{
 				max_step = 15;
 				if(pots_step[j] > 16) pots_step[j] = 1;
 			}
-		
+
 			next_step_tres = 0;
 			prev_step_tres = 0;
-			
+
 			previous_step[j] = pots_step[j];
-			
+
 			if(pots_step[j] < (max_step+1)) next_step_tres = (pots_step[j])*CalConstants[ADC_STAGEADDRESS_Ch_1+j]/(max_step+1) + 20;
 			if(pots_step[j] > 1) prev_step_tres = (pots_step[j]-1)*CalConstants[ADC_STAGEADDRESS_Ch_1+j]/(max_step+1) - 20;
-		
+
 			acc = 0;
 			for(i =0; i<10; i++)
 			{
-				if(j == 0) 
+				if(j == 0)
 				{
 					temp = (AddData[ADC_STAGEADDRESS_Ch_1]*4095/CalConstants[ADC_STAGEADDRESS_Ch_1]);
-					if(temp > 4095) temp = 4095; 
+					if(temp > 4095) temp = 4095;
 					acc += temp;
 				}
-				else 
+				else
 				{
 					temp = (AddData[ADC_STAGEADDRESS_Ch_2]*4095/CalConstants[ADC_STAGEADDRESS_Ch_2]);
-					if(temp > 4095) temp = 4095; 
+					if(temp > 4095) temp = 4095;
 					acc += temp;
 				}
 			}
-			if(pots_step[j] < (max_step+1)) {if(acc/10 > next_step_tres) 
+			if(pots_step[j] < (max_step+1)) {if(acc/10 > next_step_tres)
 			{
 				pots_step[j]++;
 			}
 			}
-			if(pots_step[j] > 1) {if(acc/10 < prev_step_tres) 
+			if(pots_step[j] > 1) {if(acc/10 < prev_step_tres)
 			{
 				pots_step[j]--;
 			}
@@ -2832,7 +2843,7 @@ int main(void)
 
 
 	};
-	
+
 
 };
 
@@ -2868,4 +2879,3 @@ void delay_ns(unsigned int ns)
 	nCount=(RCC_Clocks.HCLK_Frequency/10000000000)*ns;
 	for (; nCount!=0; nCount--);
 }
-


### PR DESCRIPTION
Round voltage level of precision of sliders or inputs to 4 decimal places.

 Ultimately when converting a voltage value to binary and then reinterpreting it as a numeric value there is a degree of variance (computers aren't perfect).
This reigns in that variance while still leaving enough wiggle room to maintain buchlas wonderful microtonality.

I believe this will fix the jitter that has been described. Will need to get my ST-Link in the mail before I could check directly, also my current oscilloscope is OLD so if someone else want's to try this and let me know, I would appreciate it. 